### PR TITLE
fix webpack4 deprecationWarning

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ WebpackUpload.prototype.apply = function (compiler) {
         });
     };
 
-    compiler.plugin('emit', onEmit);
+    compiler.hooks.done.tap('emit', onEmit);
 };
 
 


### PR DESCRIPTION
webpack4 warning
DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
fixed